### PR TITLE
Option to enable for all feeds, not just feeds in "Processing" state

### DIFF
--- a/class-enable-gf-paymentdetails.php
+++ b/class-enable-gf-paymentdetails.php
@@ -135,12 +135,16 @@ class Enable_GF_PaymentDetails extends GFAddOn {
 		}
 
 		//create drop down for payment status
-		$payment_string = '<select id="payment_status" name="payment_status">';
-		$payment_string .= '<option value="' . $payment_status . '" selected>' . $payment_status . '</option>';
-		$payment_string .= '<option value="Paid">Paid</option>';
-		$payment_string .= '</select>';
-
-		return $payment_string;
+		if (strpos($payment_status, '<select') === false) {
+			$payment_string = '<select id="payment_status" name="payment_status">';
+			$payment_string .= '<option value="' . $payment_status . '" selected>' . $payment_status . '</option>';
+			$payment_string .= '<option value="Paid">Paid</option>';
+			$payment_string .= '</select>';
+			//remove_action('gform_payment_status', array($this, 'admin_edit_payment_status'));
+			return $payment_string;
+		} else {
+			return $payment_status;
+		}
 	}
 
 	public function admin_edit_payment_date( $payment_date, $form, $entry ) {
@@ -153,19 +157,26 @@ class Enable_GF_PaymentDetails extends GFAddOn {
 			$payment_date = gmdate( 'y-m-d H:i:s' );
 		}
 
-		$input = '<input type="text" id="payment_date" name="payment_date" value="' . $payment_date . '">';
-
-		return $input;
+		if (strpos($payment_date, '<input') === false) {
+			$input = '<input type="text" id="payment_date" name="payment_date" value="' . $payment_date . '">';
+			//remove_action('gform_payment_date', array($this, 'admin_edit_payment_date'));
+			return $input;
+		} else {
+			return $payment_date;
+		}
 	}
 
 	public function admin_edit_payment_transaction_id( $transaction_id, $form, $entry ) {
 		if ( $this->payment_details_editing_disabled( $entry ) ) {
 			return $transaction_id;
 		}
-
-		$input = '<input type="text" id="custom_transaction_id" name="custom_transaction_id" value="' . $transaction_id . '">';
-
-		return $input;
+		if (strpos($transaction_id, '<input') === false) {
+			$input = '<input type="text" id="custom_transaction_id" name="custom_transaction_id" value="' . $transaction_id . '">';
+			//remove_action('gform_payment_transaction_id', array($this, 'admin_edit_payment_transaction_id'));
+			return $input;
+		} else {
+			return $transaction_id;
+		}
 	}
 
 	public function admin_edit_payment_amount( $payment_amount, $form, $entry ) {
@@ -177,11 +188,14 @@ class Enable_GF_PaymentDetails extends GFAddOn {
 			$payment_amount = GFCommon::get_order_total( $form, $entry );
 		}
 		
-		$payment_amount = GFCommon::to_money( $payment_amount, $entry['currency'] );
-
-		$input = '<input type="text" id="payment_amount" name="payment_amount" class="gform_currency" value="' . $payment_amount . '">';
-
-		return $input;
+		if (strpos($payment_amount, '<input') === false) {
+			$payment_amount = GFCommon::to_money( $payment_amount, $entry['currency'] );
+			$input = '<input type="text" id="payment_amount" name="payment_amount" class="gform_currency" value="' . $payment_amount . '">';
+			//remove_action('gform_payment_amount', array($this, 'admin_edit_payment_amount'));
+			return $input;
+		} else {
+			return $payment_amount;
+		}
 	}
 
 	public function admin_update_payment( $form, $entry_id ) {

--- a/class-enable-gf-paymentdetails.php
+++ b/class-enable-gf-paymentdetails.php
@@ -137,8 +137,8 @@ class Enable_GF_PaymentDetails extends GFAddOn {
 		//create drop down for payment status
 		if (strpos($payment_status, '<select') === false) {
 			$payment_string = '<select id="payment_status" name="payment_status">';
-			$payment_string .= '<option value="' . $payment_status . '" selected>' . $payment_status . '</option>';
-			$payment_string .= '<option value="Paid">Paid</option>';
+			$payment_string .= '<option value="Processing"'.($payment_status=='Processing'?' selected':'').'>Processing</option>';
+			$payment_string .= '<option value="Paid"'.($payment_status=='Paid'?' selected':'').'>Paid</option>';
 			$payment_string .= '</select>';
 			//remove_action('gform_payment_status', array($this, 'admin_edit_payment_status'));
 			return $payment_string;

--- a/class-enable-gf-paymentdetails.php
+++ b/class-enable-gf-paymentdetails.php
@@ -109,10 +109,11 @@ class Enable_GF_PaymentDetails extends GFAddOn {
 
 	public function add_payment_details_meta_box( $meta_boxes, $entry, $form ) {
 		if ( ! isset( $meta_boxes['payment'] ) && $this->payment_details_enabled( $form ) ) {
-			if (!isset($entry['payment_status'])) {
-				GFAPI::update_entry_property( $entry['id'], 'payment_status', 'Processing' );
-				$entry['payment_status']   = 'Processing';
-			}
+			//We maybe shouldn't override status here, because some entries do have a blank status
+			//if (!isset($entry['payment_status'])) {
+			//	GFAPI::update_entry_property( $entry['id'], 'payment_status', 'Processing' );
+			//	$entry['payment_status']   = 'Processing';
+			//}
 			if (!isset($entry['transaction_type'])) {
 				GFAPI::update_entry_property( $entry['id'], 'transaction_type', '1' );
 				$entry['transaction_type'] = '1';
@@ -136,9 +137,11 @@ class Enable_GF_PaymentDetails extends GFAddOn {
 
 		//create drop down for payment status
 		if (strpos($payment_status, '<select') === false) {
+			$status = array ('', 'Processing', 'Paid', 'Active');
 			$payment_string = '<select id="payment_status" name="payment_status">';
-			$payment_string .= '<option value="Processing"'.($payment_status=='Processing'?' selected':'').'>Processing</option>';
-			$payment_string .= '<option value="Paid"'.($payment_status=='Paid'?' selected':'').'>Paid</option>';
+			foreach ($status as $s) {
+				$payment_string .= '<option value="'.$s.'"'.($payment_status==$s?' selected':'').'>'.$s.'</option>';
+			}
 			$payment_string .= '</select>';
 			//remove_action('gform_payment_status', array($this, 'admin_edit_payment_status'));
 			return $payment_string;

--- a/enablegfpaymentdetails.php
+++ b/enablegfpaymentdetails.php
@@ -4,7 +4,7 @@
 Plugin Name: Enable Gravity Forms Payment Details
 Plugin URI:
 Description: Adds a form setting allowing the Payment Details panel to be enabled on the entry detail page for entries not processed by a payment add-on.
-Version: 0.4
+Version: 0.5
 Author: Richard Wawrzyniak
 Author URI: http://www.wawrzyniak.me
 ------------------------------------------------------------------------

--- a/enablegfpaymentdetails.php
+++ b/enablegfpaymentdetails.php
@@ -4,7 +4,7 @@
 Plugin Name: Enable Gravity Forms Payment Details
 Plugin URI:
 Description: Adds a form setting allowing the Payment Details panel to be enabled on the entry detail page for entries not processed by a payment add-on.
-Version: 0.6
+Version: 0.7.0
 Author: Richard Wawrzyniak
 Author URI: http://www.wawrzyniak.me
 ------------------------------------------------------------------------

--- a/enablegfpaymentdetails.php
+++ b/enablegfpaymentdetails.php
@@ -4,7 +4,7 @@
 Plugin Name: Enable Gravity Forms Payment Details
 Plugin URI:
 Description: Adds a form setting allowing the Payment Details panel to be enabled on the entry detail page for entries not processed by a payment add-on.
-Version: 0.5
+Version: 0.6
 Author: Richard Wawrzyniak
 Author URI: http://www.wawrzyniak.me
 ------------------------------------------------------------------------


### PR DESCRIPTION
There are occasions when editing payment details for an entry is necessary, even after it has been processed. An example would be a recurring payment to stripe which has been updated in Stripe that needs to hook back successfully to Gravity Forms.